### PR TITLE
Użycie stałej APP_PATH

### DIFF
--- a/src/includes/config.php
+++ b/src/includes/config.php
@@ -1,6 +1,6 @@
-<?php
+<?php defined('APP_PATH') OR die('Access denied');
 
-require_once 'jsonRPCClient.php';
+require_once APP_PATH.'includes/jsonRPCClient.php';
 
 $rpcname = '';
 $rpcpassword = '';
@@ -11,4 +11,4 @@ $url = sprintf('http://%s:%s@%s:%s/', $rpcname, $rpcpassword, $host, $port);
 
 $dogecoin = new jsonRPCClient($url);
 
-$link = mysqli_connect('localhost', 'USER', 'PASSWORD', 'DBNAME') or die('Error '.mysqli_error($link));
+$link = mysqli_connect('localhost', 'USER', 'PASSWORD', 'DBNAME') OR die('Error '.mysqli_error($link));

--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -1,4 +1,4 @@
-<?php
+<?php defined('APP_PATH') OR die('Access denied');
 
 /**
  * Zwraca uśrednioną wartość wypłaty

--- a/src/includes/jsonRPCClient.php
+++ b/src/includes/jsonRPCClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
 					COPYRIGHT
 
@@ -28,14 +29,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * @author sergio <jsonrpcphp@inservibile.org>
  */
 class jsonRPCClient {
-	
+
 	/**
 	 * Debug state
 	 *
 	 * @var boolean
 	 */
 	private $debug;
-	
+
 	/**
 	 * The server URL
 	 *
@@ -54,7 +55,7 @@ class jsonRPCClient {
 	 * @var boolean
 	 */
 	private $notification = false;
-	
+
 	/**
 	 * Takes the connection parameters
 	 *
@@ -71,7 +72,7 @@ class jsonRPCClient {
 		// message id
 		$this->id = 1;
 	}
-	
+
 	/**
 	 * Sets the notification state of the object. In this state, notifications are performed, instead of requests.
 	 *
@@ -83,7 +84,7 @@ class jsonRPCClient {
 							:
 							$this->notification = true;
 	}
-	
+
 	/**
 	 * Performs a jsonRCP request and gets the results as an array
 	 *
@@ -92,12 +93,12 @@ class jsonRPCClient {
 	 * @return array
 	 */
 	public function __call($method,$params) {
-		
+
 		// check
 		if (!is_scalar($method)) {
 			throw new Exception('Method name has no scalar value');
 		}
-		
+
 		// check
 		if (is_array($params)) {
 			// no keys
@@ -105,14 +106,14 @@ class jsonRPCClient {
 		} else {
 			throw new Exception('Params must be given as array');
 		}
-		
+
 		// sets notification or request task
 		if ($this->notification) {
 			$currentId = NULL;
 		} else {
 			$currentId = $this->id;
 		}
-		
+
 		// prepares the request
 		$request = array(
 						'method' => $method,
@@ -121,7 +122,7 @@ class jsonRPCClient {
 						);
 		$request = json_encode($request);
 		$this->debug && $this->debug.='***** Request *****'."\n".$request."\n".'***** End Of request *****'."\n\n";
-		
+
 		// performs the HTTP POST
 		$opts = array ('http' => array (
 							'method'  => 'POST',
@@ -139,12 +140,12 @@ class jsonRPCClient {
 		} else {
 			throw new Exception('Unable to connect to '.$this->url);
 		}
-		
+
 		// debug output
 		if ($this->debug) {
 			echo nl2br($debug);
 		}
-		
+
 		// final checks and return
 		if (!$this->notification) {
 			// check
@@ -154,12 +155,11 @@ class jsonRPCClient {
 			if (!is_null($response['error'])) {
 				throw new Exception('Request error: '.$response['error']);
 			}
-			
+
 			return $response['result'];
-			
+
 		} else {
 			return true;
 		}
 	}
 }
-?>

--- a/src/includes/jsonRPCClient.php
+++ b/src/includes/jsonRPCClient.php
@@ -1,4 +1,4 @@
-<?php
+<?php defined('APP_PATH') OR die('Access denied');
 
 /*
 					COPYRIGHT

--- a/src/index.php
+++ b/src/index.php
@@ -2,8 +2,14 @@
 
     error_reporting(0);
 
-    require_once 'includes/config.php';
-    require_once 'includes/functions.php';
+    /**
+     * Ścieżka do użycia przy ładowaniu podplików
+     * oraz dodatkowo zabezpieczenie przed ich bezpośrednim wywołaniem.
+     */
+    define('APP_PATH', __DIR__.DIRECTORY_SEPARATOR);
+
+    require_once APP_PATH.'includes/config.php';
+    require_once APP_PATH.'includes/functions.php';
 
 
     $status = $_GET['status'];

--- a/src/send.php
+++ b/src/send.php
@@ -2,7 +2,13 @@
 
 error_reporting(0);
 
-require_once 'includes/config.php';
+/**
+ * Ścieżka do użycia przy ładowaniu podplików
+ * oraz dodatkowo zabezpieczenie przed ich bezpośrednim wywołaniem.
+ */
+define('APP_PATH', __DIR__.DIRECTORY_SEPARATOR);
+
+require_once APP_PATH.'includes/config.php';
 
 /* Just things which are going to database like ip etc. */
 $today = date('y-m-d');


### PR DESCRIPTION
http://faucet.dogecoins.pl/includes/config.php

Powyższy skrypt co prawda nic nie wyświetla, ale jest (może być) wykonywany przez serwer. Może to powodować niespodziewane efekty uboczne, a wręcz może stanowić dziurę w zabezpieczeniach.

Ustalenie globalnej stałej w plikach, które mogą być odpalane bezpośrednio i sprawdzanie jej w podplikach, eliminuje ten problem.

Dodatkowo dzięki stałej `APP_PATH` możemy ładować pliki „sztywnymi” ścieżkami, które nie ulegną zmianie przy zmianie lokalizacji aktualnego pliku.
